### PR TITLE
blink-diff version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Protractor plugin for image comparison",
   "main": "index.js",
   "dependencies": {
-    "blink-diff": "1.0.7",
+    "blink-diff": "1.0.12",
     "png-image": "1.0.1",
     "camel-case": "1.2.2"
   },


### PR DESCRIPTION
Versions 1.0.7 of blink-diff references png-image 0.9.3 that is buggy and crashes process when no image is found. An update of blink-diff is sufficient to get a newer version of png-image.
